### PR TITLE
jplayer swf path corrected

### DIFF
--- a/js/dmp.player.js
+++ b/js/dmp.player.js
@@ -55,7 +55,7 @@ dmp.player.initPlayer = function(){
   // Initialize the Player.
   $("#jqueryPlayerContainer").jPlayer({
       ended: dmp.player.playNext,
-      swfPath: "/js",
+      swfPath: "/third-party/jplayer/js",
       errorAlerts: false,
       solution: solution,
       supplied: "mp3,m4a,wav,oga,webma,fla,flac",


### PR DESCRIPTION
The swf path of jplayer wasn't well set, so the flash fallback wasn't working.
This fixes this.